### PR TITLE
Add tls authentication to mqtt client

### DIFF
--- a/auditing/datacollectors/BaseCollector.py
+++ b/auditing/datacollectors/BaseCollector.py
@@ -28,6 +28,7 @@ class BaseCollector:
     # region verified property
     def setverified(self, value):
         self.__verified = value
+
         if self.verification_timer:
             self.verification_timer.cancel()
         self.verified_changed = True
@@ -42,6 +43,7 @@ class BaseCollector:
     def verify_timeout(self):
         # if the collector was verified, the timer should have been cancelled.
         # Even if it was not cancelled, it will do nothing
+
         if not self.verified:
             self.disconnect()
             self.disabled = True
@@ -68,6 +70,7 @@ class BaseCollector:
         # Try to connect the collector as in regular scenario
         self.connect()
         timeout = datetime.now() + timedelta(seconds=30)
+
         while not self.stop_testing and datetime.now() < timeout:
             sleep(1)
         self.disconnect()
@@ -85,19 +88,25 @@ class BaseCollector:
         if ratio verified_packets/total_packets > verification_threshold, sets verified=True
         """
         self.total_packets += 1
+
         if not self.verify_payload(msg):
             self.log.error("PHY payload could not be verified")
+
             return False
 
         if not self.verify_topics(msg):
             self.log.error("Topic is not usable")
+
             return False
 
         self.verified_packets += 1
+
         if self.total_packets >= self.minimum_packets \
                 and (self.verified_packets / self.total_packets) > self.verification_threshold:
             self.verified = True
+
             return True
+
         return False
 
     def verify_payload(self, msg):

--- a/auditing/db/DataCollector.py
+++ b/auditing/db/DataCollector.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from sqlalchemy import Column, DateTime, String, BigInteger, Boolean, ForeignKey, func, Enum as SQLEnum
+from sqlalchemy import Column, DateTime, String, BigInteger, Boolean, ForeignKey, func, Enum as SQLEnum, Text
 from auditing.db import session
 from sqlalchemy.dialects import postgresql, sqlite
 
@@ -27,6 +27,9 @@ class DataCollector(Base):
     user = Column(String(120), nullable=False)
     password = Column(String(120), nullable=False)
     ssl = Column(Boolean, nullable=True)
+    ca_cert  =Column(Text, nullable=True)
+    client_cert = Column(Text, nullable=True)
+    client_key = Column(Text, nullable=True)
     gateway_id = Column(String(100), nullable=True)
     organization_id = Column(BigInteger, ForeignKey("organization.id"), nullable=False)
     policy_id = Column(BigInteger, ForeignKey("policy.id"), nullable=False)
@@ -37,12 +40,14 @@ class DataCollector(Base):
     @classmethod
     def find_one_by_ip_port_and_dctype_id(cls, dctype_id, ip, port):
         return session.query(cls).filter(cls.ip == ip).filter(cls.data_collector_type_id == dctype_id).filter(cls.port == port).first()
-    
+
     @classmethod
     def find_one(cls, id=None):
         query = session.query(cls)
+
         if id:
             query = query.filter(cls.id == id)
+
         return query.first()
 
     @classmethod


### PR DESCRIPTION
Add tls authentication to paho-mqtt client. This is necessary for AWSIoT MQTT authentication (with chirpstack)

## Changes
- create NamedTemporaryFile's for the ca and client cert/key, and pass those to paho-mqtt client's tls_set
- fetch the strings with the certs from the websockets/database

## Related issues:
https://github.com/Argeniss-Software/rolaguard/issues/10